### PR TITLE
Fix Docker Image Build Error by Updating Toolset URL to New Repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 RUN useradd -m actions
 RUN apt-get -y update && apt-get install -y \
     apt-transport-https ca-certificates curl jq software-properties-common \
-    && toolset="$(curl -sL https://raw.githubusercontent.com/actions/virtual-environments/main/images/linux/toolsets/toolset-2004.json)" \
+    && toolset="$(curl -sL https://raw.githubusercontent.com/actions/runner-images/main/images/ubuntu/toolsets/toolset-2004.json)" \
     && common_packages=$(echo $toolset | jq -r ".apt.common_packages[]") && cmd_packages=$(echo $toolset | jq -r ".apt.cmd_packages[]") \
     && for package in $common_packages $cmd_packages; do apt-get install -y --no-install-recommends $package; done
 


### PR DESCRIPTION
I've updated the toolset URL, which resolves an issue encountered during the Docker image build process. This error was also reproducible locally. It seems like the refereced repository was renamed from **actions/virtual-environments** to **actions/runner-images**.

 - https://github.com/actions/virtual-environments
 - https://github.com/actions/runner-images

```
90.17 Running hooks in /etc/ca-certificates/update.d...
90.18 done.
90.22 Processing triggers for dbus (1.12.20-2ubuntu4.1) ...
90.64 parse error: Expected string key before ':' at line 1, column 4
------
Dockerfile:4
--------------------
   3 |     RUN useradd -m actions
   4 | >>> RUN apt-get -y update && apt-get install -y \
   5 | >>>     apt-transport-https ca-certificates curl jq software-properties-common \
   6 | >>>     && toolset="$(curl -sL https://raw.githubusercontent.com/actions/virtual-environments/main/images/linux/toolsets/toolset-2004.json)" \
   7 | >>>     && common_packages=$(echo $toolset | jq -r ".apt.common_packages[]") && cmd_packages=$(echo $toolset | jq -r ".apt.cmd_packages[]") \
   8 | >>>     && for package in $common_packages $cmd_packages; do apt-get install -y --no-install-recommends $package; done
   9 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -y update && apt-get install -y     apt-transport-https ca-certificates curl jq software-properties-common     && toolset=\"$(curl -sL https://raw.githubusercontent.com/actions/virtual-environments/main/images/linux/toolsets/toolset-2004.json)\"     && common_packages=$(echo $toolset | jq -r \".apt.common_packages[]\") && cmd_packages=$(echo $toolset | jq -r \".apt.cmd_packages[]\")     && for package in $common_packages $cmd_packages; do apt-get install -y --no-install-recommends $package; done" did not complete successfully: exit code: 4
```